### PR TITLE
Added listener remove functions

### DIFF
--- a/docs/wendy/com.levibostian.wendy/-wendy-config/index.html
+++ b/docs/wendy/com.levibostian.wendy/-wendy-config/index.html
@@ -87,6 +87,26 @@ This takes place when you:</p>
 <p>Listen to updates about a specific task and how it is going. Get updated when this specific task gets run by the task runner, then if it fails/succeeds/gets skipped.</p>
 </td>
 </tr>
+<tr>
+<td>
+<p><a href="remove-task-runner-listener.html">removeTaskRunnerListener</a></p>
+</td>
+<td>
+<code><span class="keyword">fun </span><span class="identifier">removeTaskRunnerListener</span><span class="symbol">(</span><span class="identifier" id="com.levibostian.wendy.WendyConfig.Companion$removeTaskRunnerListener(com.levibostian.wendy.listeners.TaskRunnerListener)/listener">listener</span><span class="symbol">:</span>&nbsp;<a href="../../com.levibostian.wendy.listeners/-task-runner-listener/index.html"><span class="identifier">TaskRunnerListener</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
+<p>Removes a listener instance added one or more times with <a href="add-task-runner-listener.html">addTaskRunnerListener</a>
+Note: if you added the same instance more than one times, this function will remove all of them</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="remove-task-status-listener.html">removeTaskStatusListener</a></p>
+</td>
+<td>
+<code><span class="keyword">fun </span><span class="identifier">removeTaskStatusListener</span><span class="symbol">(</span><span class="identifier" id="com.levibostian.wendy.WendyConfig.Companion$removeTaskStatusListener(com.levibostian.wendy.listeners.PendingTaskStatusListener)/listener">listener</span><span class="symbol">:</span>&nbsp;<a href="../../com.levibostian.wendy.listeners/-pending-task-status-listener/index.html"><span class="identifier">PendingTaskStatusListener</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
+<p>Removes a listener instance added one or more times with <a href="add-task-status-listener-for-task.html">addTaskStatusListenerForTask</a>
+Note: if you added the same instance more than one times, this function will remove all of them</p>
+</td>
+</tr>
 </tbody>
 </table>
 </BODY>

--- a/wendy/src/main/java/com/levibostian/wendy/WendyConfig.kt
+++ b/wendy/src/main/java/com/levibostian/wendy/WendyConfig.kt
@@ -56,6 +56,21 @@ class WendyConfig {
          * @see TaskRunnerListener to learn more about what callbacks to expect.
          */
         fun addTaskRunnerListener(listener: TaskRunnerListener) = taskRunnerListeners.add(WeakReference(listener))
+
+        /**
+         * Removes a listener instance added one or more times with [addTaskRunnerListener]
+         * Note: if you added the same instance more than one times, this function will remove all of them
+         *
+         * @param listener the listener instance to be removed
+         *
+         * @return true if the listener was removed at least once, false if it was collected by the GC
+         * or you didn't added it before
+         */
+        fun removeTaskRunnerListener(listener: TaskRunnerListener): Boolean {
+            return taskRunnerListeners
+                .removeAll { it.get()?.equals(listener) ?: false }
+        }
+
         internal fun getTaskRunnerListeners(): List<TaskRunnerListener> {
             if (Looper.getMainLooper().thread != Thread.currentThread()) throw RuntimeException("You must be on UI thread.")
             return taskRunnerListeners
@@ -89,6 +104,20 @@ class WendyConfig {
             Wendy.shared.getLatestError(taskId)?.let { latestError ->
                 listener.errorRecorded(taskId, latestError.errorMessage, latestError.errorId)
             }
+        }
+
+        /**
+         * Removes a listener instance added one or more times with [addTaskStatusListenerForTask]
+         * Note: if you added the same instance more than one times, this function will remove all of them
+         *
+         * @param listener the listener instance to be removed
+         *
+         * @return true if the listener was removed at least once, false if it was collected by the GC
+         * or you didn't added it before
+         */
+        fun removeTaskStatusListener(listener: PendingTaskStatusListener): Boolean {
+            return taskStatusListeners
+                .removeAll { it.listener.get()?.equals(listener) ?: false }
         }
     }
 

--- a/wendy/src/main/java/com/levibostian/wendy/WendyConfig.kt
+++ b/wendy/src/main/java/com/levibostian/wendy/WendyConfig.kt
@@ -59,7 +59,7 @@ class WendyConfig {
 
         /**
          * Removes a listener instance added one or more times with [addTaskRunnerListener]
-         * Note: if you added the same instance more than one times, this function will remove all of them
+         * Note: if you added the same instance more than one time, this function will remove all of them
          *
          * @param listener the listener instance to be removed
          *
@@ -108,7 +108,7 @@ class WendyConfig {
 
         /**
          * Removes a listener instance added one or more times with [addTaskStatusListenerForTask]
-         * Note: if you added the same instance more than one times, this function will remove all of them
+         * Note: if you added the same instance more than one time, this function will remove all of them
          *
          * @param listener the listener instance to be removed
          *


### PR DESCRIPTION
This should close #48 
I added two listener removal functions.. but i think we need to discuss some situations

* If the task is being 'listened' at the time of the removal.. what should happen?
* We should really remove all instances when they're the same?
* Should we use predicates instead of instances as param? (i personally prefer predicates, the dev has more control over it)
* Is there any thread restriction to remove a listener?

Also, we need some tests on Wendy and examples on the example app.. 
I think that testing needs to be done after #50 ... and the example app i don't have ideas for the remove functions uses